### PR TITLE
Support arbitrary helm property overrides in helmDeploy

### DIFF
--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -198,3 +198,18 @@ def getHelmReleaseOverrides(Map map=[:]) {
 
     return options
 }
+
+def String getDomainName(String url) throws URISyntaxException {
+    URI uri = new URI(url);
+    String domain = uri.getHost();
+    return domain.startsWith("www.") ? domain.substring(4) : domain;
+}
+
+def String getSubDomainName(String domain) {
+    return domain.substring(domain.indexOf('.') + 1);
+}
+
+// Used to get the subdomain Jenkins is hosted on for new ingress resources.
+def String getSubDomainNameFromURL(String url) {
+    return getSubDomainName(getDomainName(url));
+}

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -36,7 +36,7 @@ def helmDeploy(Map args) {
         if (args.hasProperty('set') && args.set instanceof Map) {
           release_overrides = getHelmReleaseOverrides(args.set)
         }
-        sh "helm upgrade --install ${args.name} ${args.chart_dir} " + release_overrides ? "--set ${release_overrides}" : "" + "--namespace=${args.name}"
+        sh "helm upgrade --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.name}"
 
         echo "Application ${args.name} successfully deployed. Use helm status ${args.name} to check"
     }

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -24,6 +24,10 @@ def helmConfig() {
 def helmDeploy(Map args) {
     //configure helm client and confirm tiller process is installed
     helmConfig()
+    def String release_overrides = ""
+    if (args.set) {
+      release_overrides = getHelmReleaseOverrides(args.set)
+    }
 
     if (args.dry_run) {
         println "Running dry-run deployment"
@@ -31,11 +35,8 @@ def helmDeploy(Map args) {
         sh "helm upgrade --dry-run --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.namespace}"
     } else {
         println "Running deployment"
+
         sh "helm dependency update ${args.chart_dir}"
-        def String release_overrides = ""
-        if (args.set) {
-          release_overrides = getHelmReleaseOverrides(args.set)
-        }
         sh "helm upgrade --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.namespace}"
 
         echo "Application ${args.name} successfully deployed. Use helm status ${args.name} to check"

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -44,24 +44,12 @@ def helmDeploy(Map args) {
     if (args.dry_run) {
         println "Running dry-run deployment"
 
-<<<<<<< HEAD
-        sh "helm upgrade --dry-run --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.namespace}"
+        sh "helm upgrade --dry-run --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${namespace}"
     } else {
         println "Running deployment"
 
         sh "helm dependency update ${args.chart_dir}"
-        sh "helm upgrade --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.namespace}"
-=======
-        sh "helm upgrade --dry-run --install ${args.name} ${args.chart_dir} --set imageTag=${args.version_tag},replicas=${args.replicas},cpu=${args.cpu},memory=${args.memory},ingress.hostname=${args.hostname} --namespace=${namespace}"
-    } else {
-        println "Running deployment"
-
-        // reimplement --wait once it works reliable
-        sh "helm upgrade --install ${args.name} ${args.chart_dir} --set imageTag=${args.version_tag},replicas=${args.replicas},cpu=${args.cpu},memory=${args.memory},ingress.hostname=${args.hostname} --namespace=${namespace}"
-
-        // sleeping until --wait works reliably
-        sleep(20)
->>>>>>> upstream/master
+        sh "helm upgrade --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${namespace}"
 
         echo "Application ${args.name} successfully deployed. Use helm status ${args.name} to check"
     }

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -33,8 +33,11 @@ def helmDeploy(Map args) {
         println "Running deployment"
         sh "helm dependency update ${args.chart_dir}"
         def String release_overrides = ""
+        println args.hasProperty('set')
+        println args.set instanceof Map
         if (args.hasProperty('set') && args.set instanceof Map) {
-          release_overrides = getHelmReleaseOverrides(args.set)
+          releas_overrides = getHelmReleaseOverrides(args.set)
+          println release_overrides
         }
         sh "helm upgrade --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.name}"
 
@@ -157,4 +160,15 @@ def getMapValues(Map map=[:]) {
     }
 
     return map_values
+}
+
+@NonCPS
+def getHelmReleaseOverrides(Map map=[:]) {
+    // jenkins and workflow restriction force this function instead of map.each(): https://issues.jenkins-ci.org/browse/JENKINS-27421
+    def options = ""
+    map.each { key, value ->
+        options += "$key=$value,"
+    }
+
+    return options
 }

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -24,6 +24,19 @@ def helmConfig() {
 def helmDeploy(Map args) {
     //configure helm client and confirm tiller process is installed
     helmConfig()
+    println args.dry_run
+    if (args.dry_run) {
+      println "dryrun1"
+    }
+    if (args.dry_run == 'true') {
+      println "dryrun2"
+    }
+    if (args.dry_run == true) {
+      println "dryrun2.5"
+    }
+    if (args.hasProperty('dry_run')) {
+      println "dryrun3"
+    }
 
     if (args.dry_run) {
         println "Running dry-run deployment"

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -33,11 +33,8 @@ def helmDeploy(Map args) {
         println "Running deployment"
         sh "helm dependency update ${args.chart_dir}"
         def String release_overrides = ""
-        println args.hasProperty('set')
-        println args.set instanceof Map
-        if (args.hasProperty('set') && args.set instanceof Map) {
-          releas_overrides = getHelmReleaseOverrides(args.set)
-          println release_overrides
+        if (args.set) {
+          release_overrides = getHelmReleaseOverrides(args.set)
         }
         sh "helm upgrade --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.name}"
 

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -31,7 +31,12 @@ def helmDeploy(Map args) {
         sh "helm upgrade --dry-run --install ${args.name} ${args.chart_dir} --set ImageTag=${args.version_tag},Replicas=${args.replicas},Cpu=${args.cpu},Memory=${args.memory} --namespace=${args.name}"
     } else {
         println "Running deployment"
-        sh "helm upgrade --install ${args.name} ${args.chart_dir} --set ImageTag=${args.version_tag},Replicas=${args.replicas},Cpu=${args.cpu},Memory=${args.memory} --namespace=${args.name}"
+        sh "helm dependency update ${args.chart_dir}"
+        def String release_overrides = ""
+        if (args.hasProperty('set') && args.set instanceof Map) {
+          release_overrides = getHelmReleaseOverrides(args.set)
+        }
+        sh "helm upgrade --install ${args.name} ${args.chart_dir} " + release_overrides ? "--set ${release_overrides}" : "" + "--namespace=${args.name}"
 
         echo "Application ${args.name} successfully deployed. Use helm status ${args.name} to check"
     }

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -25,6 +25,7 @@ def helmDeploy(Map args) {
     //configure helm client and confirm tiller process is installed
     helmConfig()
     println args.dry_run
+    println args
     if (args.dry_run) {
       println "dryrun1"
     }

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -24,20 +24,6 @@ def helmConfig() {
 def helmDeploy(Map args) {
     //configure helm client and confirm tiller process is installed
     helmConfig()
-    println args.dry_run
-    println args
-    if (args.dry_run) {
-      println "dryrun1"
-    }
-    if (args.dry_run == 'true') {
-      println "dryrun2"
-    }
-    if (args.dry_run == true) {
-      println "dryrun2.5"
-    }
-    if (args.hasProperty('dry_run')) {
-      println "dryrun3"
-    }
 
     if (args.dry_run) {
         println "Running dry-run deployment"

--- a/src/io/estrado/Pipeline.groovy
+++ b/src/io/estrado/Pipeline.groovy
@@ -28,7 +28,7 @@ def helmDeploy(Map args) {
     if (args.dry_run) {
         println "Running dry-run deployment"
 
-        sh "helm upgrade --dry-run --install ${args.name} ${args.chart_dir} --set ImageTag=${args.version_tag},Replicas=${args.replicas},Cpu=${args.cpu},Memory=${args.memory} --namespace=${args.name}"
+        sh "helm upgrade --dry-run --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.namespace}"
     } else {
         println "Running deployment"
         sh "helm dependency update ${args.chart_dir}"
@@ -36,7 +36,7 @@ def helmDeploy(Map args) {
         if (args.set) {
           release_overrides = getHelmReleaseOverrides(args.set)
         }
-        sh "helm upgrade --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.name}"
+        sh "helm upgrade --install ${args.name} ${args.chart_dir} " + (release_overrides ? "--set ${release_overrides}" : "") + " --namespace=${args.namespace}"
 
         echo "Application ${args.name} successfully deployed. Use helm status ${args.name} to check"
     }


### PR DESCRIPTION
This allows helmDeploy to be called as follows:

```
pipeline.helmDeploy(
    dry_run: false,
    name: config.app.name,
    chart_dir: chart_dir,
    set: [
        "django.persistence.storageClass": "gluster-heketi",
        "postgresql.persistence.storageClass": "gluster-heketi",
        "redis.persistence.storageClass": "gluster-heketi",
        "nginx.ingress.enabled": true,
        "nginx.ingress.hosts": "{test.example.com}"
    ]
)
```

It also runs `helm dependency update` prior to deploying.